### PR TITLE
Add text tool and panning improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Ejecuta `tsc` para generar `script.js` y abre `index.html` en un navegador moder
 
 - **Pincel**: traza l\u00edneas libres.
 - **Rect\u00e1ngulo** y **L\u00ednea**: haz clic y arrastra.
-- **Seleccionar**: pulsa sobre cualquier forma para moverla o ajustar sus v\u00e9rtices.
-- **Pan**: mant\u00e9n pulsada la barra espaciadora o usa el bot\u00f3n derecho del rat\u00f3n y arrastra.
+- **Seleccionar**: pulsa sobre cualquier forma para moverla o ajustar sus v\u00e9rtices. Si haces clic en una zona vac\u00eda podr\u00e1s desplazar el tablero.
+- **Texto**: crea un cuadro de texto para escribir.
+- **Pan**: mant\u00e9n pulsada la barra espaciadora o usa el bot\u00f3n derecho del rat\u00f3n y arrastra. Tambi\u00e9n puedes arrastrar en vac\u00edo con la herramienta de selecci\u00f3n.
 - **Zoom**: rueda del rat\u00f3n o gesto de pellizco.
 
 ## Despliegue en GitHub Pages

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <button id="tool-draw" title="Pincel">🖌️</button>
   <button id="tool-rect" title="Rect\u00e1ngulo">◻️</button>
   <button id="tool-line" title="L\u00ednea">➖</button>
+  <button id="tool-text" title="Texto">🅣</button>
   <button id="tool-select" title="Seleccionar">🖱️</button>
 </div>
 <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- integrate a new `text` tool with editable boxes
- allow dragging the canvas when clicking on an empty area with the select tool
- update interface for text object support
- compile TypeScript
- document new controls in README

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68405f53c5ac8323b46d47a9e929c34a