### PR TITLE
Add text color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Ejecuta `tsc` para generar `script.js` y abre `index.html` en un navegador moder
 
 - **Pincel**: traza l\u00edneas libres.
 - **Rect\u00e1ngulo** y **L\u00ednea**: haz clic y arrastra.
-- **Seleccionar**: pulsa sobre cualquier forma para moverla o ajustar sus v\u00e9rtices.
-- **Pan**: mant\u00e9n pulsada la barra espaciadora o usa el bot\u00f3n derecho del rat\u00f3n y arrastra.
+- **Seleccionar**: pulsa sobre cualquier forma para moverla o ajustar sus v\u00e9rtices. Si haces clic en una zona vac\u00eda podr\u00e1s desplazar el tablero.
+- **Texto**: crea un cuadro de texto para escribir. El contenido se edita directamente dentro del cuadro. Al activar esta herramienta se muestra un menú de colores a la izquierda para cambiar el tono del texto. Haz doble clic para modificar un texto existente.
+- **Pan**: mant\u00e9n pulsada la barra espaciadora o usa el bot\u00f3n derecho del rat\u00f3n y arrastra. Tambi\u00e9n puedes arrastrar en vac\u00edo con la herramienta de selecci\u00f3n.
 - **Zoom**: rueda del rat\u00f3n o gesto de pellizco.
 
 ## Despliegue en GitHub Pages

--- a/index.html
+++ b/index.html
@@ -17,7 +17,18 @@
   <button id="tool-draw" title="Pincel">🖌️</button>
   <button id="tool-rect" title="Rect\u00e1ngulo">◻️</button>
   <button id="tool-line" title="L\u00ednea">➖</button>
+  <button id="tool-text" title="Texto">🅣</button>
   <button id="tool-select" title="Seleccionar">🖱️</button>
+</div>
+<div id="text-colors" class="color-menu">
+  <button data-color="#000000" style="background:#000"></button>
+  <button data-color="#ff0000" style="background:#ff0000"></button>
+  <button data-color="#00ff00" style="background:#00ff00"></button>
+  <button data-color="#0000ff" style="background:#0000ff"></button>
+  <button data-color="#ffff00" style="background:#ffff00"></button>
+  <button data-color="#ff00ff" style="background:#ff00ff"></button>
+  <button data-color="#00ffff" style="background:#00ffff"></button>
+  <button data-color="#ffa500" style="background:#ffa500"></button>
 </div>
 <script src="script.js"></script>
 <script>

--- a/style.css
+++ b/style.css
@@ -5,3 +5,8 @@ html,body{margin:0;height:100%;overflow:hidden;font-family:sans-serif;}
 #actions{position:fixed;top:10px;right:10px;background:rgba(255,255,255,.9);box-shadow:0 0 8px rgba(0,0,0,.2);display:flex;gap:6px;padding:5px;border-radius:4px;}
 #actions button{background:none;border:none;width:40px;height:40px;padding:0;display:flex;align-items:center;justify-content:center;cursor:pointer;}
 #actions img{width:24px;height:24px;pointer-events:none;}
+.text-edit{position:fixed;margin:0;padding:0;border:1px dashed orange;resize:none;overflow:hidden;background:transparent;color:#000;outline:none;font-family:sans-serif;}
+#text-colors{position:fixed;left:20px;bottom:80px;display:none;flex-direction:column;gap:8px;background:rgba(255,255,255,.9);padding:8px;border-radius:10px;box-shadow:0 0 8px rgba(0,0,0,.2);}
+#text-colors.show{display:flex;}
+#text-colors button{width:24px;height:24px;border-radius:50%;border:2px solid #fff;cursor:pointer;padding:0;}
+#text-colors button.active{outline:2px solid orange;}


### PR DESCRIPTION
## Summary
- show a palette of eight color circles when using the Text tool
- support storing a color on each text object and apply it while editing
- remember color when loading drawings
- mention the color menu in the README

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68405f53c5ac8323b46d47a9e929c34a