### PR TITLE
Fix caching issues and clarify version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Ejecuta `tsc` para generar `script.js` y abre `index.html` en un navegador moder
 ## Despliegue en GitHub Pages
 
 Tras fusionar a `main`, copia todos los archivos al branch `gh-pages` y publica desde la configuraci\u00f3n de GitHub Pages. Si modificas los archivos est\u00e1ticos recuerda incrementar la constante `CACHE` en `sw.js` para que los navegadores descarguen la nueva versi\u00f3n.
+
+Para verificar que la página desplegada corresponde a la última compilación, incrementa también el número de versión que aparece en el elemento `<title>` de `index.html`. Así, al cargar la web se puede comprobar fácilmente que se está viendo la versión correcta.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Whiteboard V2</title>
+<title>Whiteboard V3</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -32,7 +32,15 @@
 </div>
 <script src="script.js"></script>
 <script>
-if('serviceWorker' in navigator){ navigator.serviceWorker.register('sw.js'); }
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js');
+  let refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
+}
 </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Bump cache version whenever static assets change
-const CACHE='static-v4';
+const CACHE='static-v5';
 const ASSETS=[
   './',
   'index.html',


### PR DESCRIPTION
## Summary
- update README about bumping title version
- auto-reload page when a new service worker takes control
- bump cached resources version
- bump web title version

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_6841d5d4d1f08323b08e5dd7a1686834