### PR TITLE
Add menu for saved drawings

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,15 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Whiteboard V3</title>
+<title>Whiteboard V4</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div id="save-menu">
+  <select id="drawing-list"></select>
+  <input id="drawing-title" type="text" placeholder="Título">
+  <button id="save-drawing" title="Guardar">💾</button>
+</div>
 <canvas id="board" width="5000" height="5000"></canvas>
 <div id="actions">
   <button id="clear" title="Borrar todo">🗑</button>

--- a/style.css
+++ b/style.css
@@ -10,3 +10,6 @@ html,body{margin:0;height:100%;overflow:hidden;font-family:sans-serif;}
 #text-colors.show{display:flex;}
 #text-colors button{width:24px;height:24px;border-radius:50%;border:2px solid #fff;cursor:pointer;padding:0;}
 #text-colors button.active{outline:2px solid orange;}
+#save-menu{position:fixed;top:10px;left:10px;background:rgba(255,255,255,.9);box-shadow:0 0 8px rgba(0,0,0,.2);display:flex;gap:6px;padding:5px;border-radius:4px;align-items:center;}
+#save-menu select,#save-menu input{font-size:14px;}
+#save-menu button{background:none;border:none;cursor:pointer;font-size:20px;}

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Bump cache version whenever static assets change
-const CACHE='static-v5';
+const CACHE='static-v6';
 const ASSETS=[
   './',
   'index.html',


### PR DESCRIPTION
## Summary
- add save menu markup
- support multiple saved drawings in script and UI
- style new dropdown and buttons
- bump to Whiteboard V4 and update service worker cache

## Testing
- `npx tsc`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6842a8bf34fc83238a7f2e66d55cba9a