### PR TITLE
Fix selection handles after saving and add mobile styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,6 +65,7 @@ function loadFromSave(id) {
     const s = saves.find(v => v.id === id);
     if (!s)
         return;
+    finishTextEdit();
     state.objects = JSON.parse(JSON.stringify(s.data));
     currentSaveId = id;
     localStorage.setItem('current-save', id);
@@ -72,6 +73,9 @@ function loadFromSave(id) {
         saveTitle.value = s.title;
     undoStack = [];
     redoStack = [];
+    state.selected = null;
+    state.current = null;
+    state.handle = undefined;
     scheduleSave();
     draw();
 }
@@ -79,9 +83,13 @@ function createNewBoard() {
     currentSaveId = null;
     if (saveTitle)
         saveTitle.value = '';
+    finishTextEdit();
     state.objects = [];
     undoStack = [];
     redoStack = [];
+    state.selected = null;
+    state.current = null;
+    state.handle = undefined;
     localStorage.removeItem('current-save');
     scheduleSave();
     draw();
@@ -108,6 +116,9 @@ function saveCurrent() {
     populateSaveList();
     if (saveSelect)
         saveSelect.value = currentSaveId !== null && currentSaveId !== void 0 ? currentSaveId : '';
+    state.selected = null;
+    state.current = null;
+    state.handle = undefined;
 }
 function pushUndo() {
     undoStack.push(JSON.parse(JSON.stringify(state.objects)));

--- a/script.ts
+++ b/script.ts
@@ -101,12 +101,16 @@ function populateSaveList(): void {
 function loadFromSave(id: string): void {
   const s = saves.find(v => v.id === id);
   if (!s) return;
+  finishTextEdit();
   state.objects = JSON.parse(JSON.stringify(s.data));
   currentSaveId = id;
   localStorage.setItem('current-save', id);
   if (saveTitle) saveTitle.value = s.title;
   undoStack = [];
   redoStack = [];
+  state.selected = null;
+  state.current = null;
+  state.handle = undefined;
   scheduleSave();
   draw();
 }
@@ -114,9 +118,13 @@ function loadFromSave(id: string): void {
 function createNewBoard(): void {
   currentSaveId = null;
   if (saveTitle) saveTitle.value = '';
+  finishTextEdit();
   state.objects = [];
   undoStack = [];
   redoStack = [];
+  state.selected = null;
+  state.current = null;
+  state.handle = undefined;
   localStorage.removeItem('current-save');
   scheduleSave();
   draw();
@@ -141,6 +149,9 @@ function saveCurrent(): void {
   saveSaves();
   populateSaveList();
   if (saveSelect) saveSelect.value = currentSaveId ?? '';
+  state.selected = null;
+  state.current = null;
+  state.handle = undefined;
 }
 
 function pushUndo(): void {

--- a/style.css
+++ b/style.css
@@ -13,3 +13,9 @@ html,body{margin:0;height:100%;overflow:hidden;font-family:sans-serif;}
 #save-menu{position:fixed;top:10px;left:10px;background:rgba(255,255,255,.9);box-shadow:0 0 8px rgba(0,0,0,.2);display:flex;gap:6px;padding:5px;border-radius:4px;align-items:center;}
 #save-menu select,#save-menu input{font-size:14px;}
 #save-menu button{background:none;border:none;cursor:pointer;font-size:20px;}
+
+@media (max-width:600px){
+  #save-menu{top:auto;bottom:20px;left:50%;transform:translateX(-50%);flex-direction:column;padding:10px;gap:8px;}
+  #save-menu select,#save-menu input{font-size:16px;width:200px;}
+  #save-menu button{font-size:24px;}
+}


### PR DESCRIPTION
## Summary
- clear selections when saving or switching boards so orange handles disappear
- adjust save menu layout for mobile screens

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_6842b2a72e2c832389391a549f8c719e